### PR TITLE
Try and force precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TriangularSolve"
 uuid = "d5829a12-d9aa-46ab-831f-fb7c9ab06edf"
 authors = ["chriselrod <elrodc@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 CloseOpenIntervals = "fb6a15b2-703c-40df-9091-08a04967cfa9"

--- a/src/TriangularSolve.jl
+++ b/src/TriangularSolve.jl
@@ -522,13 +522,18 @@ function __init__()
   end
 end
 
-A = rand(1, 1)
-B = rand(1, 1)
-res = similar(A)
-rdiv!(res, A, UpperTriangular(B))
-rdiv!(res, A, UnitUpperTriangular(B))
+let
+  while true
+    A = rand(1, 1)
+    B = rand(1, 1)
+    res = similar(A)
+    rdiv!(res, A, UpperTriangular(B))
+    rdiv!(res, A, UnitUpperTriangular(B))
 
-__init__()
-ldiv!(res, LowerTriangular(B), A)
-ldiv!(res, UnitLowerTriangular(B), A)
+    __init__()
+    ldiv!(res, LowerTriangular(B), A)
+    ldiv!(res, UnitLowerTriangular(B), A)
+    break
+  end
+end
 end

--- a/src/TriangularSolve.jl
+++ b/src/TriangularSolve.jl
@@ -522,4 +522,13 @@ function __init__()
   end
 end
 
+A = rand(1, 1)
+B = rand(1, 1)
+res = similar(A)
+rdiv!(res, A, UpperTriangular(B))
+rdiv!(res, A, UnitUpperTriangular(B))
+
+__init__()
+ldiv!(res, LowerTriangular(B), A)
+ldiv!(res, UnitLowerTriangular(B), A)
 end


### PR DESCRIPTION
Try and force precompilation with the solve and Polyester.batch 

```julia
using OrdinaryDiffEq, SnoopCompile

function lorenz(du,u,p,t)
 du[1] = 10.0(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz,u0,tspan)
alg = Rodas5()
tinf = @snoopi_deep solve(prob,alg)

Before:
InferenceTimingNode: 2.285476/19.503069 on Core.Compiler.Timings.ROOT() with 54 direct children

After:
InferenceTimingNode: 2.247376/19.289887 on Core.Compiler.Timings.ROOT() with 54 direct children
```

Depressing.