### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/src/TriangularSolve.jl
+++ b/src/TriangularSolve.jl
@@ -740,13 +740,13 @@ function __init__()
   end
 end
 #=
-using SnoopPrecompile
+using PrecompileTools
 @static if VERSION >= v"1.8.0-beta1"
-  @precompile_setup begin
+  @setup_workload begin
     A = rand(1, 1)
     B = rand(1, 1)
     res = similar(A)
-    @precompile_all_calls begin
+    @compile_workload begin
       rdiv!(res, A, UpperTriangular(B))
       rdiv!(res, A, UnitUpperTriangular(B))
       rdiv!(res, A, UpperTriangular(B), Val(false))


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
