### PR TITLE
Improve static compilation, reduce uses of `lubuffer`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TriangularSolve"
 uuid = "d5829a12-d9aa-46ab-831f-fb7c9ab06edf"
 authors = ["chriselrod <elrodc@gmail.com> and contributors"]
-version = "0.1.22"
+version = "0.2.0"
 
 [deps]
 CloseOpenIntervals = "fb6a15b2-703c-40df-9091-08a04967cfa9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TriangularSolve"
 uuid = "d5829a12-d9aa-46ab-831f-fb7c9ab06edf"
 authors = ["chriselrod <elrodc@gmail.com> and contributors"]
-version = "0.1.21"
+version = "0.1.22"
 
 [deps]
 CloseOpenIntervals = "fb6a15b2-703c-40df-9091-08a04967cfa9"

--- a/README.md
+++ b/README.md
@@ -132,7 +132,74 @@ Platform Info:
 Environment:
   JULIA_NUM_THREADS = 8
 ```
+Single-threaded benchmarks on an M1 mac:
+```julia
+julia> N = 100;
 
+julia> A = rand(N,N); B = rand(N,N); C = similar(A);
+
+julia> @benchmark TriangularSolve.rdiv!($C, $A, UpperTriangular($B), Val(false)) # false means single threaded
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  21.416 μs …  34.458 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     21.624 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   21.767 μs ± 491.788 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+    ▃ ▆██ ▆▄ ▁                 ▃▄ ▄▂          ▁            ▂▃▁ ▂
+  ▃▇█▁███▁██▁█▆▁▁▁▁▁▁▁▁▁▁▁▁▁▃█▁██▁███▁▆▃▁▁▆▇▁██▁█▆▅▁▄▃▁▃▃▇▁███ █
+  21.4 μs       Histogram: log(frequency) by time      23.2 μs <
+
+ Memory estimate: 0 bytes, allocs estimate: 0.
+
+julia> @benchmark rdiv!(copyto!($C, $A), UpperTriangular($B))
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  39.124 μs … 57.749 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     46.166 μs              ┊ GC (median):    0.00%
+ Time  (mean ± σ):   46.274 μs ±  1.766 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+                              ▁▁▄▂▆▃█▅▇▄▇▅▃▃▁▃▁▂               
+  ▂▁▁▂▂▂▂▂▁▂▂▂▂▂▂▃▃▃▃▃▄▄▅▅▆▅▇▇████████████████████▆▇▆▆▅▆▅▅▄▃▃ ▅
+  39.1 μs         Histogram: frequency by time        50.2 μs <
+
+ Memory estimate: 0 bytes, allocs estimate: 0.
+
+julia> @benchmark ldiv!($C, LowerTriangular($B), $A)
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  48.291 μs …  57.833 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     49.124 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   49.306 μs ± 802.143 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+    ▁▃▅▆▇██▇██▇▇▆▅▄▂▂▁▁▁▂▁▁▁▁▁▁▁ ▁▁▁                           ▃
+  ▃████████████████████████████████████▇▆▄▂▄▃▂▃▃▄▄▃▆▅▇▇▇██▇█▇▇ █
+  48.3 μs       Histogram: log(frequency) by time        53 μs <
+
+ Memory estimate: 0 bytes, allocs estimate: 0.
+
+julia> @benchmark TriangularSolve.ldiv!($C, LowerTriangular($B), $A, Val(false)) # false means single threaded
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  34.249 μs …  40.208 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     34.375 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   34.748 μs ± 774.675 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+  ▆██▆▃▄▅▃                ▁▁▄▅▅▃▂▁                     ▂▃▂  ▁▂ ▂
+  ████████▁▁▃▁▁▁▁▁▃▄▃▁▁▃██████████▇▅▄▅▅▆▄▄▄▄▄▅▄▄▃▅▃▄▃▅█████▇██ █
+  34.2 μs       Histogram: log(frequency) by time      37.1 μs <
+
+ Memory estimate: 0 bytes, allocs estimate: 0.
+```
+Or
+```julia
+julia> @benchmark TriangularSolve.ldiv!($C, LowerTriangular($B), $A, Val(false)) # false means single threaded
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  23.750 μs …  30.541 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     23.875 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   23.948 μs ± 316.293 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+   ▃▁▆ █ ▇▆▆ ▄ ▁                               ▁ ▁         ▁ ▁ ▂
+  ▅███▆█▁███▄█▁██▇▁▄▁▁▁▁▁▃▁▁▁▁▁▁▁▃▁▁▁▃▁▁▁▁▁▆▁▇▆█▁█▁▇▆▅▁▅▁▇▆█▁█ █
+  23.8 μs       Histogram: log(frequency) by time        25 μs <
+
+ Memory estimate: 0 bytes, allocs estimate: 0.
+```
 
 For editing convenience (you can copy/paste the above into a REPL and it should automatically strip `julia> `s and outputs, but the above is less convenient to edit if you want to try changing the benchmarks):
 ```julia

--- a/src/TriangularSolve.jl
+++ b/src/TriangularSolve.jl
@@ -439,7 +439,7 @@ end
     end
   else
     quote
-      mask = VectorizationBase.mask($WS, $(static(R)))
+      mask = VectorizationBase.mask($(static(Wpad)), $(static(R)))
       i = $(Unroll{2,1,W,1,Wpad,(-1 % UInt),1})(($z, n))
       vstore!(spc, C_u, i, mask)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,8 +41,5 @@ end
 end
 
 using Aqua
-Aqua.test_all(
-  TriangularSolve;
-  ambiguities = false
-)
+Aqua.test_all(TriangularSolve; ambiguities = false)
 @test isempty(Test.detect_ambiguities(TriangularSolve))


### PR DESCRIPTION
Static compilation and `lubuffer` aren't currently compatible.

Unfortunately, this currently results in a runtime regression. On an M1 mac, PR, for `Float64` matrices:
```julia
julia> @benchmark TriangularSolve.ldiv!($C, LowerTriangular($B), $A, Val(false)) # 100 x 100
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  34.249 μs …  40.208 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     34.375 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   34.748 μs ± 774.675 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆██▆▃▄▅▃                ▁▁▄▅▅▃▂▁                     ▂▃▂  ▁▂ ▂
  ████████▁▁▃▁▁▁▁▁▃▄▃▁▁▃██████████▇▅▄▅▅▆▄▄▄▄▄▅▄▄▃▅▃▄▃▅█████▇██ █
  34.2 μs       Histogram: log(frequency) by time      37.1 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark TriangularSolve.ldiv!($C, LowerTriangular($B), $A, Val(false)) # 200 x 200
BenchmarkTools.Trial: 3593 samples with 1 evaluation.
 Range (min … max):  274.204 μs … 299.746 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     277.162 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   277.524 μs ±   2.547 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▃▆▇█▇▅▂▁                                                  
  ▂▃▄▆█████████▆▄▄▃▃▃▂▂▂▂▂▂▂▂▂▁▂▁▂▁▁▂▂▂▂▂▂▂▁▂▁▂▂▁▁▂▁▁▁▁▁▂▁▁▁▂▂▂ ▃
  274 μs           Histogram: frequency by time          295 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
Main branch:
```julia
julia> @benchmark TriangularSolve.ldiv!($C, LowerTriangular($B), $A, Val(false)) # 100 x 100
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  23.750 μs …  30.541 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     23.875 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   23.948 μs ± 316.293 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▃▁▆ █ ▇▆▆ ▄ ▁                               ▁ ▁         ▁ ▁ ▂
  ▅███▆█▁███▄█▁██▇▁▄▁▁▁▁▁▃▁▁▁▁▁▁▁▃▁▁▁▃▁▁▁▁▁▆▁▇▆█▁█▁▇▆▅▁▅▁▇▆█▁█ █
  23.8 μs       Histogram: log(frequency) by time        25 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark TriangularSolve.ldiv!($C, LowerTriangular($B), $A, Val(false)) # 200 x 200
BenchmarkTools.Trial: 5408 samples with 1 evaluation.
 Range (min … max):  182.289 μs … 207.247 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     182.539 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   183.907 μs ±   3.616 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▅  ▄▅                   ▂                          ▃▁        ▁
  ██▄▃██▆▇▇▅▅▃▃▅▆▅▆█▇▆▆▃▄▃▃██▄▄▄▆▄▅▅▅▄▁▃▁▁▁▄▃▁▁▁▃▁▃▄▁▁██▆▄▅▃▁▄▇ █
  182 μs        Histogram: log(frequency) by time        198 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
`rdiv!` is uneffected, because it is not currently using a buffer.

I'll have to look into different approaches.